### PR TITLE
working with custom locale list

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -31,25 +31,38 @@ list1 <- function (x) {
 }
 
 check_locale <- function(x) {
-  json <- list.files(path = path_locales_js())
-  njson <- gsub("\\.json", "", json)
-  if (!x %in% njson) {
-    stop(paste(
-      "Invalid locale, must be one of:",
-      paste(njson, collapse = ", ")
-    ), call. = FALSE)
+  if(is.character(x)){
+    json <- list.files(path = path_locales_js())
+    njson <- gsub("\\.json", "", json)
+    if (!x %in% njson) {
+      stop(paste(
+        "Invalid locale, must be one of:",
+        paste(njson, collapse = ", ")
+      ), call. = FALSE)
+    }
   }
 }
 
 #' @importFrom jsonlite read_json
 read_locale <- function(locale, as_text = FALSE) {
   check_locale(locale)
-  path <- file.path(path_locales_js(), paste0(locale, ".json"))
-  if (as_text) {
-    paste(readLines(con = path, encoding = "UTF-8"), collapse = "")
-  } else {
-    jsonlite::read_json(path = path)
+  if(is.character(locale)){
+    path <- file.path(path_locales_js(), paste0(locale, ".json"))
+    if (as_text) {
+      locale <- paste(readLines(con = path, encoding = "UTF-8"), collapse = "")
+    } else {
+      locale <- jsonlite::read_json(path = path)
+    }
   }
+  if(is.list(locale)){
+    default_locale <- read_default_locale()
+    locale <- modifyList(default_locale, locale)
+  }
+  locale
 }
 
+read_default_locale <- function(){
+  path <- file.path(path_locales_js(), "en-US.json")
+  jsonlite::read_json(path = path)
+}
 

--- a/tests/testthat/test-d3_format.R
+++ b/tests/testthat/test-d3_format.R
@@ -36,6 +36,27 @@ test_that("d3_format works with locale", {
   expect_false(identical(fr, en))
 })
 
+test_that("d3_format works with custom locale", {
+  my_locale <- list(
+    decimal = "|",
+    thousands = "*"
+  )
+  fmt <- d3_format(",", locale = my_locale)(c(123456.789, 0.3424321))
+  expect_equal(grepl("\\*",fmt),c(TRUE,FALSE))
+  expect_true(grepl("^0|",fmt[2]))
+
+  bad_locale <- list(
+    decimal = ",",
+    grouping = c(3),
+    currency = c("=$\u00a0", "\u00a0€")
+  )
+  expect_equal(read_locale(bad_locale)$thousands,
+               read_default_locale()$thousands)
+
+  fmt <- d3_format("$.2f", locale = bad_locale)(c(1500.3))
+  expect_equal(fmt, "=$\u00a01500,30\u00a0€")
+})
+
 test_that("bad locale", {
   expect_error(d3_format(",", locale = "elves"))
 })


### PR DESCRIPTION
Users can now give a list with custom defined locales.
`read_locale` now checks if the local is a list and merges the list with the default `en-US` locale.